### PR TITLE
GH-4: Add Map support and some error handling

### DIFF
--- a/spring-cloud-starter-stream-sink-field-value-counter/README.adoc
+++ b/spring-cloud-starter-stream-sink-field-value-counter/README.adoc
@@ -4,6 +4,7 @@
 A field value counter is a Metric used for counting occurrences of unique values for a named field in a message payload. This sinks supports the following payload types out of the box:
 
 * POJO (Java bean)
+* Map
 * Tuple
 * JSON String
 
@@ -43,7 +44,7 @@ The field value counter on the field _users_ will contain:
 The **$$field-value-counter$$** $$sink$$ has the following options:
 
 //tag::configuration-properties[]
-$$field-value-counter.field-name$$:: $$<documentation missing>$$ *($$String$$, default: `$$<none>$$`)*
+$$field-value-counter.field-name$$:: $$The field name to extract for the counter.$$ *($$String$$, default: `$$<none>$$`)*
 $$field-value-counter.name$$:: $$The name of the counter to increment.$$ *($$String$$, default: `$$<none>$$`)*
 $$field-value-counter.name-expression$$:: $$A SpEL expression (against the incoming Message) to derive the name of the counter to increment.$$ *($$Expression$$, default: `$$<none>$$`)*
 $$spring.redis.database$$:: $$Database index used by the connection factory.$$ *($$Integer$$, default: `$$0$$`)*

--- a/spring-cloud-starter-stream-sink-field-value-counter/src/main/java/org/springframework/cloud/stream/app/field/value/counter/sink/FieldValueCounterSinkProperties.java
+++ b/spring-cloud-starter-stream-sink-field-value-counter/src/main/java/org/springframework/cloud/stream/app/field/value/counter/sink/FieldValueCounterSinkProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,26 +16,31 @@
 
 package org.springframework.cloud.stream.app.field.value.counter.sink;
 
+import javax.validation.constraints.AssertTrue;
+import javax.validation.constraints.NotNull;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.expression.Expression;
 import org.springframework.expression.common.LiteralExpression;
 import org.springframework.validation.annotation.Validated;
 
-import javax.validation.constraints.AssertTrue;
-import javax.validation.constraints.NotNull;
-
 /**
  * @author Ilayaperumal Gopinathan
  * @author Gary Russell
+ * @author Artem Bilan
  */
 @ConfigurationProperties("field-value-counter")
 @Validated
 public class FieldValueCounterSinkProperties {
 
-	private String fieldName;
 	/**
-	 * The default name of the counter
+	 * The field name to extract for the counter.
+	 */
+	private String fieldName;
+
+	/**
+	 * The default name of the counter.
 	 */
 	@Value("${spring.application.name:field-value-counter}")
 	private String defaultName;

--- a/spring-cloud-starter-stream-sink-field-value-counter/src/test/java/org/springframework/cloud/stream/app/field/value/counter/sink/FieldValueCounterSinkTests.java
+++ b/spring-cloud-starter-stream-sink-field-value-counter/src/test/java/org/springframework/cloud/stream/app/field/value/counter/sink/FieldValueCounterSinkTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.cloud.stream.app.field.value.counter.sink;
 
 import static org.junit.Assert.assertEquals;
@@ -43,9 +44,13 @@ import org.springframework.tuple.TupleBuilder;
 
 /**
  * @author Ilayaperumal Gopinathan
+ * @author Artem Bilan
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringBootTest({"server.port:-1", "field-value-counter.name:FVCounter", "field-value-counter.fieldName:test"})
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
+		properties = {
+				"field-value-counter.name:FVCounter",
+				"field-value-counter.fieldName:test" })
 @DirtiesContext
 public class FieldValueCounterSinkTests {
 
@@ -149,6 +154,20 @@ public class FieldValueCounterSinkTests {
 		assertEquals(1, this.fieldValueCounterRepository.findOne(FVC_NAME).getFieldValueCounts().get("{test2=Hi}").longValue());
 	}
 
+	@Test
+	public void testMapPayloadFieldName() {
+		Map<String, String> map = new HashMap<>();
+		map.put("test", "Hello");
+		Message<Map<String, String>> message = MessageBuilder.withPayload(map).build();
+		sink.input().send(message);
+		assertEquals(1,
+				this.fieldValueCounterRepository.findOne(FVC_NAME)
+						.getFieldValueCounts()
+						.get("Hello")
+						.longValue());
+	}
+
+
 	private class TestPojoList {
 
 		private List<String> test;
@@ -164,6 +183,7 @@ public class FieldValueCounterSinkTests {
 	}
 
 	private class TestPojoTuple {
+
 		private Tuple test;
 
 		public Tuple getTest() {
@@ -187,5 +207,7 @@ public class FieldValueCounterSinkTests {
 		public void setTest(Map<String, String> test) {
 			this.test = test;
 		}
+
 	}
+
 }


### PR DESCRIPTION
Fixes spring-cloud-stream-app-starters/field-value-counter#4

* Provide a `Map` payload type support for field extraction
* Add error logging when field isn't available in the payload
* Log info when value is `null` - nothing to count though