### PR TITLE
Add byte[] payload support for field-value-counter

### DIFF
--- a/spring-cloud-starter-stream-sink-field-value-counter/README.adoc
+++ b/spring-cloud-starter-stream-sink-field-value-counter/README.adoc
@@ -79,8 +79,7 @@ $$spring.redis.password$$:: $$Login password of the redis server.$$ *($$String$$
 $$spring.redis.port$$:: $$Redis server port.$$ *($$Integer$$, default: `$$6379$$`)*
 $$spring.redis.ssl$$:: $$Whether to enable SSL support.$$ *($$Boolean$$, default: `$$false$$`)*
 $$spring.redis.timeout$$:: $$Connection timeout.$$ *($$Duration$$, default: `$$<none>$$`)*
-$$spring.redis.url$$:: $$Connection URL. Overrides host, port, and password. User is ignored. Example:
- redis://user:password@example.com:6379$$ *($$String$$, default: `$$<none>$$`)*
+$$spring.redis.url$$:: $$Connection URL. Overrides host, port, and password. User is ignored. Example: redis://user:password@example.com:6379$$ *($$String$$, default: `$$<none>$$`)*
 //end::configuration-properties[]
 
 == Build

--- a/spring-cloud-starter-stream-sink-field-value-counter/src/main/java/org/springframework/cloud/stream/app/field/value/counter/sink/FieldValueCounterSinkConfiguration.java
+++ b/spring-cloud-starter-stream-sink-field-value-counter/src/main/java/org/springframework/cloud/stream/app/field/value/counter/sink/FieldValueCounterSinkConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,6 +46,7 @@ import org.springframework.util.StringUtils;
  * @author Ilayaperumal Gopinathan
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Christian Tzolov
  */
 @EnableBinding(Sink.class)
 @Import(FieldValueCounterSinkStoreConfiguration.class)
@@ -64,9 +65,9 @@ public class FieldValueCounterSinkConfiguration {
 	@ServiceActivator(inputChannel = Sink.INPUT)
 	public void process(Message<?> message) {
 		Object payload = message.getPayload();
-		if (payload instanceof String) {
+		if (payload instanceof byte[]) {
 			try {
-				payload = jsonToTupleTransformer.transformPayload(payload.toString());
+				payload = jsonToTupleTransformer.transformPayload(new String((byte[]) payload, "UTF-8"));
 			}
 			catch (Exception e) {
 				throw new MessageTransformationException(message, e.getMessage(), e);
@@ -165,6 +166,5 @@ public class FieldValueCounterSinkConfiguration {
 	protected String computeMetricName(Message<?> message) {
 		return fvcSinkProperties.getComputedNameExpression().getValue(message, CharSequence.class).toString();
 	}
-
 
 }

--- a/spring-cloud-starter-stream-sink-field-value-counter/src/test/java/org/springframework/cloud/stream/app/field/value/counter/sink/FieldValueCounterSinkTests.java
+++ b/spring-cloud-starter-stream-sink-field-value-counter/src/test/java/org/springframework/cloud/stream/app/field/value/counter/sink/FieldValueCounterSinkTests.java
@@ -74,11 +74,11 @@ public class FieldValueCounterSinkTests {
 	@Test
 	public void testFieldNameIncrement() {
 		assertNotNull(this.sink.input());
-		Message<String> message = MessageBuilder.withPayload("{\"test\": \"Hi\"}").build();
+		Message<byte[]> message = MessageBuilder.withPayload("{\"test\": \"Hi\"}".getBytes()).build();
 		sink.input().send(message);
-		message = MessageBuilder.withPayload("{\"test\": \"Hello\"}").build();
+		message = MessageBuilder.withPayload("{\"test\": \"Hello\"}".getBytes()).build();
 		sink.input().send(message);
-		message = MessageBuilder.withPayload("{\"test\": \"Hi\"}").build();
+		message = MessageBuilder.withPayload("{\"test\": \"Hi\"}".getBytes()).build();
 		sink.input().send(message);
 		assertEquals(2, this.fieldValueCounterRepository.findOne(FVC_NAME).getFieldValueCounts().get("Hi").longValue());
 		assertEquals(1, this.fieldValueCounterRepository.findOne(FVC_NAME).getFieldValueCounts().get("Hello").longValue());
@@ -87,9 +87,9 @@ public class FieldValueCounterSinkTests {
 	@Test
 	public void testFieldNameDecrement() {
 		assertNotNull(this.sink.input());
-		Message<String> message = MessageBuilder.withPayload("{\"test\": \"Hi\"}").build();
+		Message<byte[]> message = MessageBuilder.withPayload("{\"test\": \"Hi\"}".getBytes()).build();
 		sink.input().send(message);
-		message = MessageBuilder.withPayload("{\"test\": \"Hi\"}").build();
+		message = MessageBuilder.withPayload("{\"test\": \"Hi\"}".getBytes()).build();
 		sink.input().send(message);
 		assertEquals(2, this.fieldValueCounterRepository.findOne(FVC_NAME).getFieldValueCounts().get("Hi").longValue());
 		this.fieldValueCounterRepository.decrement(FVC_NAME, "Hi", 2);

--- a/spring-cloud-starter-stream-sink-field-value-counter/src/test/java/org/springframework/cloud/stream/app/field/value/counter/sink/FieldValueCounterSinkWithDefaultsTests.java
+++ b/spring-cloud-starter-stream-sink-field-value-counter/src/test/java/org/springframework/cloud/stream/app/field/value/counter/sink/FieldValueCounterSinkWithDefaultsTests.java
@@ -65,11 +65,11 @@ public class FieldValueCounterSinkWithDefaultsTests {
 	@Test
 	public void testFieldNameIncrement() {
 		assertNotNull(this.sink.input());
-		Message<String> message = MessageBuilder.withPayload("{\"test\": \"Hi\"}").build();
+		Message<byte[]> message = MessageBuilder.withPayload("{\"test\": \"Hi\"}".getBytes()).build();
 		sink.input().send(message);
-		message = MessageBuilder.withPayload("{\"test\": \"Hello\"}").build();
+		message = MessageBuilder.withPayload("{\"test\": \"Hello\"}".getBytes()).build();
 		sink.input().send(message);
-		message = MessageBuilder.withPayload("{\"test\": \"Hi\"}").build();
+		message = MessageBuilder.withPayload("{\"test\": \"Hi\"}".getBytes()).build();
 		sink.input().send(message);
 		assertEquals(2, this.fieldValueCounterRepository.findOne(FVC_NAME).getFieldValueCounts().get("Hi").longValue());
 		assertEquals(1, this.fieldValueCounterRepository.findOne(FVC_NAME).getFieldValueCounts().get("Hello").longValue());


### PR DESCRIPTION
  - With SCSt 2.X+ the payloads for JSON and TEXT content types is encoded in byte arrays. Use to be String

  Resolves #162